### PR TITLE
Bug when supplying proxy_host and proxy_port

### DIFF
--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -43,8 +43,8 @@ class HTTPClient(object):
             assert proxy_port is not None, \
                 'you have to provide proxy_port if you have set proxy_host'
             self.use_proxy = True
-            connection_host = self.proxy_host
-            connection_port = self.proxy_port
+            connection_host = proxy_host
+            connection_port = proxy_port
         else:
             self.use_proxy = False
         if ssl and ssl_options is None:


### PR DESCRIPTION
Code was referencing `self.proxy_host` and `self.proxy_port` instead of
`proxy_host` and `proxy_port`
