### PR TITLE
added the ability to override the quoter used for a given url.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,6 +1,6 @@
 # geventhttpclient
 
-A high performance, concurrent HTTP client library for python using 
+A high performance, concurrent HTTP client library for python using
 [gevent](http://gevent.org).
 
 **geventhttpclient** use a fast [http parser](http://github.com/joyent/http-parser),
@@ -158,3 +158,9 @@ a concurrency of 10. See *benchmarks* folder.
 - httplib2 with geventhttpclient monkey patch (*benchmarks/httplib2_patched.py*): **~2500 req/s**
 - geventhttpclient.HTTPClient (*benchmarks/httpclient.py*): **~4000 req/s**
 
+## Testing
+
+Tests can be run via the following command
+```bash
+python setup.py nosetests
+```

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,31 @@
 from distutils.core import setup
 from setuptools.extension import Extension
 from setuptools import find_packages
+import sys
+
+setup_requires = []
+if 'nosetests' in sys.argv:
+    setup_requires.append('nose')
+
 
 httpparser = Extension('geventhttpclient._parser',
-                    sources = ['ext/_parser.c', 'ext/http_parser.c'],
-                    include_dirs = ['ext'])
+                    sources=['ext/_parser.c', 'ext/http_parser.c'],
+                    include_dirs=['ext'])
+
 
 setup(name='geventhttpclient',
-       version = '1.0a',
-       description = 'http client library for gevent',
+       version='1.0a',
+       description='http client library for gevent',
        author="Antonin Amand",
        author_email="antonin.amand@gmail.com",
        packages=find_packages('src'),
        package_dir={'': 'src'},
-       ext_modules = [httpparser],
+       ext_modules=[httpparser],
        include_package_data=True,
        install_requires=[
         'gevent >= 0.13'
+       ],
+       setup_requires=setup_requires,
+       tests_require=[
+        'pytest',
        ])
-

--- a/src/geventhttpclient/tests/test_url.py
+++ b/src/geventhttpclient/tests/test_url.py
@@ -32,3 +32,9 @@ def test_empty():
     assert url.netloc == ''
     str(url) == 'http:///'
 
+def test_no_quote():
+    surl = '/path/to/something?param=value&other=tr*ue'
+    url1 = URL(surl, quoter=str)
+    url2 = URL(surl)
+    assert url1.query_string == "other=tr*ue&param=value"
+    assert url2.query_string == "other=tr%2Aue&param=value"

--- a/src/geventhttpclient/url.py
+++ b/src/geventhttpclient/url.py
@@ -34,9 +34,9 @@ class URL(object):
         'https': 443
     }
 
-    __slots__ = ('scheme', 'host', 'port', 'path', 'query', 'fragment')
+    __slots__ = ('scheme', 'host', 'port', 'path', 'query', 'fragment', 'quoter')
 
-    def __init__(self, url=None):
+    def __init__(self, url=None, quoter=quote_plus):
         if url is not None:
             self.scheme, netloc, self.path, \
                 query, self.fragment = urlparse.urlsplit(url)
@@ -61,6 +61,8 @@ class URL(object):
                 self.query[key] = value
             else:
                 self.query[key] = value[0]
+
+        self.quoter = quoter
 
     @property
     def netloc(self):
@@ -92,10 +94,10 @@ class URL(object):
             if isinstance(value, list):
                 for item in value:
                     params.append("%s=%s" % (
-                        quote_plus(key), quote_plus(str(item))))
+                        self.quoter(key), self.quoter(str(item))))
             else:
                 params.append("%s=%s" % (
-                    quote_plus(key), quote_plus(str(value))))
+                    self.quoter(key), self.quoter(str(value))))
         if params:
             return "&".join(params)
         return ''


### PR DESCRIPTION
This makes it so you can use methods other than quote_plus to encode urls without having to monkey patch anything.

I also made a version that works on a class level instead of an instance level but I think this is cleaner.
