### PR TITLE
Enforce HTTP spec compliant paths (section 5.1.2)

### DIFF
--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -123,6 +123,10 @@ class HTTPClient(object):
             if request_uri.startswith('/'):
                 base_url = base_url[:-1]
             request_url = base_url + request_url
+        else:
+            if not request_url.startswith('/'):
+                request_url = '/' + request_url
+
         request = method + " " + request_url + " " + self.version + "\r\n"
 
         for field, value in header_fields.iteritems():


### PR DESCRIPTION
Currently it is possible to perform non compliant HTTP requests by giving a path that does not start with a "/".  See http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2
