### PR TITLE
Bugfix: HTTP version always reported as 1.1 from from parser.

### DIFF
--- a/ext/_parser.c
+++ b/ext/_parser.c
@@ -219,7 +219,7 @@ static PyObject*
 PyHTTPResponseParser_get_http_version(PyHTTPResponseParser *self)
 {
     return PyString_FromFormat("HTTP/%u.%u", self->parser->http_major,
-        self->parser->http_major);
+        self->parser->http_minor);
 }
 
 static PyObject*


### PR DESCRIPTION
http_major was used twice...
