### PR TITLE
Suggest using url.request_uri

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -32,7 +32,7 @@ url = URL('http://gevent.org/')
 http = HTTPClient(url.host)
 
 # issue a get request
-response = http.get(url.path)
+response = http.get(url.request_uri)
 
 # read status_code
 response.status_code
@@ -93,7 +93,7 @@ url['access_token'] = TOKEN
 # reuse them.
 http = HTTPClient.from_url(url, concurrency=10)
 
-response = http.get(url.query_string)
+response = http.get(url.request_uri)
 assert response.status_code == 200
 
 # response comply to the read protocol. It passes the stream to
@@ -104,7 +104,7 @@ def print_friend_username(http, friend_id):
     friend_url = URL('/' + str(friend_id))
     friend_url['access_token'] = TOKEN
     # the greenlet will block until a connection is available
-    response = http.get(friend_url.query_string)
+    response = http.get(friend_url.request_uri)
     assert response.status_code == 200
     friend = json.load(response)
     if friend.has_key('username'):


### PR DESCRIPTION
Using request_uri prevents user from accidentally not passing their path or query string.

Happy to hear your thoughts if otherwise, but as a new user of this library, this bit me pretty badly.
