### PR TITLE
Clear client pool on close

### DIFF
--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -310,3 +310,4 @@ class HTTPClientPool(object):
     def close(self):
         for client in self.clients.values():
             client.close()
+        self.clients.clear()


### PR DESCRIPTION
This PR clears underlying pool in `HTTPClientPool.close` making it usable after calling this method, similar to how urllib3 [`PoolManager.clear`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html#urllib3.PoolManager.clear) works. Ideally, this method should be renamed to avoid confusion, but this could break backward compatibility for users that manage pools on their own. For those users that don't use client pool instance after closing it (probably most of them, duh) this change shouldn't be noticeable.

Why make this change then? It is motivated purely by Locust. Unfortunately, its geventhttpclient adapter allows for [injecting client pools](https://github.com/locustio/locust/blob/f76c1822be846781ac71b2d6d3d1cf4632cf27f0/locust/contrib/fasthttp.py#L472-L476) and encourages writing code like this

<details>
<summary>Locust example</summary>

```python
from geventhttpclient.client import HTTPClientPool
from locust import FastHttpUser, task


class MyUser(FastHttpUser):
    host = "http://localhost"
    client_pool = HTTPClientPool(concurrency=100)

    @task
    def index(self):
        self.client.get('/')
```

</details>

Reusing a single instance of client pool causes problems when users are garbage collected (when scaling down or restarting a test), because it also collects `UserAgent`, which in turn closes its client pool in `__del__`.

https://github.com/geventhttpclient/geventhttpclient/blob/d79022bb27bb4362d97b5b3a3b4e719369d82d75/src/geventhttpclient/useragent.py#L289-L290

Any new request to the same host will raise an exception, as clients aren't usable after close (its connection pool checks for that and raises an exception, similar to urllib3). To add more confusion, requests to hosts not used previously in the client pool will work, as their clients weren't created and then closed earlier.

<details>
<summary>Traceback</summary>

```
Traceback (most recent call last):
  File "/Users/dominik/src/locust/locust/user/task.py", line 347, in run
    self.execute_next_task()
  File "/Users/dominik/src/locust/locust/user/task.py", line 372, in execute_next_task
    self.execute_task(self._task_queue.pop(0))
  File "/Users/dominik/src/locust/locust/user/task.py", line 493, in execute_task
    task(self.user)
  File "/Users/dominik/src/perf-tests/src/index/locustfile.py", line 11, in index
    self.client.get('/')
  File "/Users/dominik/src/locust/locust/contrib/fasthttp.py", line 262, in get
    return self.request("GET", url, **kwargs)
  File "/Users/dominik/src/locust/locust/contrib/fasthttp.py", line 213, in request
    response = self._send_request_safe_mode(method, built_url, payload=data, headers=headers, **kwargs)
  File "/Users/dominik/src/locust/locust/contrib/fasthttp.py", line 125, in _send_request_safe_mode
    return self.client.urlopen(url, method=method, **kwargs)
  File "/Users/dominik/src/geventhttpclient/src/geventhttpclient/useragent.py", line 460, in urlopen
    last_error = self._handle_error(e, url=req.url)
  File "/Users/dominik/src/geventhttpclient/src/geventhttpclient/useragent.py", line 425, in _handle_error
    raise reraise(type(e), e, sys.exc_info()[2])
  File "/Users/dominik/src/locust/venv/lib/python3.8/site-packages/six.py", line 719, in reraise
    raise value
  File "/Users/dominik/src/geventhttpclient/src/geventhttpclient/useragent.py", line 455, in urlopen
    resp = self._urlopen(req)
  File "/Users/dominik/src/locust/locust/contrib/fasthttp.py", line 481, in _urlopen
    resp = client.request(
  File "/Users/dominik/src/geventhttpclient/src/geventhttpclient/client.py", line 226, in request
    sock = self._connection_pool.get_socket()
  File "/Users/dominik/src/geventhttpclient/src/geventhttpclient/connectionpool.py", line 161, in get_socket
    raise RuntimeError('connection pool closed')
RuntimeError: connection pool closed
```

</details>

Another possible solution would be removing `__del__` altogether, but this could cause socket leaks for users that don't call `UserAgent.close` or `HTTPClientPool.close` explicitly (e.g. Locust) or fixing the problem directly in Locust, but it'd probably require overloading `__del__` and I'd like to avoid that if possible.