### PR TITLE
update MANIFEST.in to include llhttp headers and licenses

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 include src/geventhttpclient/*.py
 include ext/*.c
 include ext/*.h
+include llhttp/*.h
+include llhttp/*.c
+include llhttp/LICENSE-MIT
 recursive-include src/geventhttpclient/tests *
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
Thanks for maintaining this!

We ran into a spot of bother with this downstream on [conda-forge](https://github.com/conda-forge/geventhttpclient-feedstock/pull/28) [logs](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=587638&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=841356e0-85bb-57d8-dbbc-852e683d1642&l=253):

```
 ext/_parser.c:4:10: fatal error: llhttp.h: No such file or directory
      4 | #include <llhttp.h>
        |          ^~~~~~~~~~
  compilation terminated.
  error: command '~/bld/bin/x86_64-conda-linux-gnu-cc' failed with exit code 1
  error: subprocess-exited-with-error
  
  × Running setup.py install for geventhttpclient did not run successfully.
  │ exit code: 1
```

I think we're just missing the `.h` files, this tries to fix that.

Also, this includes the upstream license file verbatim, which is also useful for downstreams.

Thanks again!