### PR TITLE
use single recursive-include in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,7 @@
 include src/geventhttpclient/*.py
 include ext/*.c
 include ext/*.h
-include llhttp/*.h
-include llhttp/*.c
-include llhttp/LICENSE-MIT
+recursirve-include llhttp *.h *.c LICENSE-MIT
 recursive-include src/geventhttpclient/tests *
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
This reworks #171 to include everything relevant to `llhttp` in a single line.

My apologies for not trying it out first. If you'd prefer, I can add an sdist build workflow.