### PR TITLE
Revert "Prefer using create_default_ssl_context" (#170)

### DIFF
--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -198,11 +198,6 @@ try:
         from gevent.ssl import match_hostname
     except ImportError:
         from backports.ssl_match_hostname import match_hostname
-
-    try:
-        from gevent.ssl import create_default_context
-    except ImportError:
-        create_default_context = None
 except ImportError:
     pass
 else:
@@ -222,27 +217,17 @@ else:
             'cert_reqs': gevent.ssl.CERT_REQUIRED
         }
 
+        ssl_context_factory = getattr(gevent.ssl, "create_default_context",
+                                      None)
+
         def __init__(self,
                      connection_host,
                      connection_port,
                      request_host,
-                     request_port,
-                     insecure=False,
-                     ssl_context_factory=None,
-                     ssl_options=None,
-                     **kw):
-            self.insecure = insecure
-
-            self.ssl_options = self.default_options.copy()
-            self.ssl_options.update(ssl_options or {})
-
-            ssl_context_factory = ssl_context_factory or create_default_context
-            if ssl_context_factory is not None:
-                self.ssl_context = ssl_context_factory(cafile=self.ssl_options['ca_certs'])
-                self.ssl_context.check_hostname = not self.insecure
-            else:
-                self.ssl_context = None
-
+                     request_port, **kw):
+            self.ssl_options = kw.pop("ssl_options", {})
+            self.ssl_context_factory = kw.pop('ssl_context_factory', None)
+            self.insecure = kw.pop('insecure', False)
             super(SSLConnectionPool, self).__init__(connection_host,
                                                     connection_port,
                                                     request_host,
@@ -257,8 +242,10 @@ else:
         def _connect_socket(self, sock, address):
             sock = super(SSLConnectionPool, self)._connect_socket(sock, address)
 
-            if self.ssl_context is None:
-                return gevent.ssl.wrap_socket(sock, **self.ssl_options)
+            if self.ssl_context_factory is None:
+                ssl_options = self.default_options.copy()
+                ssl_options.update(self.ssl_options)
+                return gevent.ssl.wrap_socket(sock, **ssl_options)
             else:
-                server_hostname = self.ssl_options.get('server_hostname', self._request_host)
-                return self.ssl_context.wrap_socket(sock, server_hostname=server_hostname)
+                return self.ssl_context_factory().wrap_socket(sock,
+                                                              **self.ssl_options)

--- a/src/geventhttpclient/tests/test_ssl.py
+++ b/src/geventhttpclient/tests/test_ssl.py
@@ -1,7 +1,3 @@
-import gevent.monkey
-
-gevent.monkey.patch_ssl()
-
 try:
     import unittest.mock as mock
 except ImportError:


### PR DESCRIPTION
Backing out that change for now, as it was a breaking change for locust.
```
    def __init__(self,
                 connection_host,
                 connection_port,
                 request_host,
                 request_port,
                 insecure=False,
                 ssl_context_factory=None,
                 ssl_options=None,
                 **kw):
        self.insecure = insecure

        self.ssl_options = self.default_options.copy()
        self.ssl_options.update(ssl_options or {})

        ssl_context_factory = ssl_context_factory or create_default_context
        if ssl_context_factory is not None:
>           self.ssl_context = ssl_context_factory(cafile=self.ssl_options['ca_certs'])
E           TypeError: TestFastHttpSession.test_custom_ssl_context_fail_with_bad_context.<locals>.create_custom_context() got an unexpected keyword argument 'cafile'

/usr/local/lib/python3.10/site-packages/geventhttpclient/connectionpool.py:241: TypeError
========================================================================================================== short test summary info ===========================================================================================================
FAILED locust/test/test_fasthttp.py::TestFastHttpSession::test_custom_ssl_context_fail_with_bad_context - TypeError: TestFastHttpSession.test_custom_ssl_context_fail_with_bad_context.<locals>.create_custom_context() got an unexpected k...
```
This reverts commit 7390bd184f8443baf1bb3652ee3b3142949c42bb.