### PR TITLE
Prefer using create_default_ssl_context

### DIFF
--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -238,9 +238,7 @@ else:
 
             ssl_context_factory = ssl_context_factory or create_default_context
             if ssl_context_factory is not None:
-                self.ssl_context = ssl_context_factory()
-                self.ssl_context.load_verify_locations(cafile=self.ssl_options['ca_certs'])
-                self.ssl_context.check_hostname = not self.insecure
+                self.init_ssl_context(ssl_context_factory)
             else:
                 self.ssl_context = None
 
@@ -249,6 +247,15 @@ else:
                                                     request_host,
                                                     request_port,
                                                     **kw)
+
+        def init_ssl_context(self, ssl_context_factory):
+            ca_certs = self.ssl_options['ca_certs']
+            try:
+                self.ssl_context = ssl_context_factory(cafile=ca_certs)
+            except TypeError:
+                self.ssl_context = ssl_context_factory()
+                self.ssl_context.load_verify_locations(cafile=ca_certs)
+            self.ssl_context.check_hostname = not self.insecure
 
         def after_connect(self, sock):
             super(SSLConnectionPool, self).after_connect(sock)

--- a/src/geventhttpclient/tests/test_ssl.py
+++ b/src/geventhttpclient/tests/test_ssl.py
@@ -1,3 +1,7 @@
+import gevent.monkey
+
+gevent.monkey.patch_ssl()
+
 try:
     import unittest.mock as mock
 except ImportError:


### PR DESCRIPTION
Following up on https://github.com/geventhttpclient/geventhttpclient/pull/170#issuecomment-1279539917.

Locust was failing because of these 2 functions
* https://github.com/locustio/locust/blob/8f6b2442d2e82a5f4651a2d008629aa7db4e2a94/locust/contrib/fasthttp.py#L61-L65
* https://github.com/locustio/locust/blob/8f6b2442d2e82a5f4651a2d008629aa7db4e2a94/locust/test/test_fasthttp.py#L213-L217

not accepting any arguments, but SSLConnectionPool expected factories to have the same signature as ssl.create_default_context. Now it doesn't pass any arguments to the factory and loads certs using SSLContext method.

Locust tests are now passing. Sorry for causing any trouble!