### PR TITLE
Add source_host and source_port and fixed some tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
   online: tests which require internet access
+  virtual_interface: tests which require a virtual eth interface

--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -76,7 +76,8 @@ class HTTPClient(object):
                  ssl=False, ssl_options=None, ssl_context_factory=None,
                  insecure=False,
                  proxy_host=None, proxy_port=None, version=HTTP_11,
-                 headers_type=Headers):
+                 headers_type=Headers,
+                 **kwargs):
         if headers is None:
             headers = {}
         self.host = host
@@ -114,7 +115,8 @@ class HTTPClient(object):
                 network_timeout=network_timeout,
                 connection_timeout=connection_timeout,
                 disable_ipv6=disable_ipv6,
-                use_proxy=self.use_proxy
+                use_proxy=self.use_proxy,
+                **kwargs
             )
         else:
             self.ssl = False
@@ -129,7 +131,8 @@ class HTTPClient(object):
                 network_timeout=network_timeout,
                 connection_timeout=connection_timeout,
                 disable_ipv6=disable_ipv6,
-                use_proxy=self.use_proxy
+                use_proxy=self.use_proxy,
+                **kwargs
             )
         self.version = version
         self.headers_type = headers_type

--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -50,12 +50,16 @@ class ConnectionPool(object):
                  size=5, disable_ipv6=False,
                  connection_timeout=DEFAULT_CONNECTION_TIMEOUT,
                  network_timeout=DEFAULT_NETWORK_TIMEOUT,
-                 use_proxy=False):
+                 use_proxy=False,
+                 source_host=None,
+                 source_port=0):
         self._closed = False
         self._connection_host = connection_host
         self._connection_port = connection_port
         self._request_host = request_host
         self._request_port = request_port
+        self._source_host = source_host
+        self._source_port = source_port
         self._semaphore = lock.BoundedSemaphore(size)
         self._socket_queue = gevent.queue.LifoQueue(size)
         self._use_proxy = use_proxy
@@ -111,6 +115,8 @@ class ConnectionPool(object):
 
             try:
                 sock.settimeout(self.connection_timeout)
+                if self._source_host is not None:
+                    sock.bind((self._source_host, self._source_port))
                 sock = self._connect_socket(sock, sock_info[-1])
                 self.after_connect(sock)
                 sock.settimeout(self.network_timeout)

--- a/src/geventhttpclient/tests/test_client.py
+++ b/src/geventhttpclient/tests/test_client.py
@@ -278,26 +278,34 @@ def test_file_post():
         with wsgiserver(check_upload(b"123456789", 9)):
             client = HTTPClient(*listener)
             with open(name, 'rb') as body:
-                client.post('/', body)
+                resp = client.post('/', body)
     finally:
         os.remove(name)
+    assert resp is not None
+    assert resp.status_code == 200
 
 def test_bytes_post():
     with wsgiserver(check_upload(b"12345", 5)):
         client = HTTPClient(*listener)
-        client.post('/', b"12345")
+        resp = client.post('/', b"12345")
+    assert resp is not None
+    assert resp.status_code == 200
 
 def test_string_post():
     with wsgiserver(check_upload("12345", 5)):
         client = HTTPClient(*listener)
-        client.post('/', "12345")
+        resp = client.post('/', "12345")
+    assert resp is not None
+    assert resp.status_code == 200
 
 def test_unicode_post():
     byte_string = b'\xc8\xb9\xc8\xbc\xc9\x85'
     unicode_string = byte_string.decode('utf-8')
     with wsgiserver(check_upload(byte_string, len(byte_string))):
         client = HTTPClient(*listener)
-        client.post('/', unicode_string)
+        resp = client.post('/', unicode_string)
+    assert resp is not None
+    assert resp.status_code == 200
 
 
 def check_src_ip(ip, port):
@@ -318,5 +326,5 @@ def test_source_address():
     with wsgiserver(check_src_ip(src_ip, src_port)):
         client = HTTPClient(*listener, source_host=src_ip, source_port=src_port)
         resp = client.get("/")
-        assert resp is not None
-        assert resp.status_code == 200
+    assert resp is not None
+    assert resp.status_code == 200

--- a/src/geventhttpclient/tests/test_client.py
+++ b/src/geventhttpclient/tests/test_client.py
@@ -292,7 +292,7 @@ def test_bytes_post():
     assert resp.status_code == 200
 
 def test_string_post():
-    with wsgiserver(check_upload("12345", 5)):
+    with wsgiserver(check_upload(b"12345", 5)):
         client = HTTPClient(*listener)
         resp = client.post('/', "12345")
     assert resp is not None


### PR DESCRIPTION
This PR adds the functionality of binding the socket to a different (ip,port) than the default ones.

also fixes some tests that were not failing correctly. 

I was trying to benchmark a rate limiter for my services and I had to override some internal methods of the lib. So I thought this could be built in.

