### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         include:
           - {name: Windows, python: '3.9', os: windows-latest, tox: py38}
           - {name: Mac, python: '3.9', os: macos-latest, tox: py39}
+          - {name: '3.12', python: '3.12', os: ubuntu-latest, tox: py312}
           - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}

--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -1,6 +1,7 @@
 import gevent.queue
 import gevent.socket
 import os
+import sys
 import six
 
 _CA_CERTS = None
@@ -195,7 +196,8 @@ try:
     import gevent.ssl
 
     try:
-        from gevent.ssl import match_hostname
+        if sys.version_info[:2] < (3, 7):
+            from gevent.ssl import match_hostname
     except ImportError:
         from backports.ssl_match_hostname import match_hostname
 
@@ -259,7 +261,7 @@ else:
 
         def after_connect(self, sock):
             super(SSLConnectionPool, self).after_connect(sock)
-            if not self.insecure:
+            if not self.insecure and sys.version_info[:2] < (3, 7):
                 match_hostname(sock.getpeercert(), self._request_host)
 
         def _connect_socket(self, sock, address):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,39,310,311}
+envlist = py{27,35,36,37,38,39,310,311,312}
 [testenv]
 allowlist_externals =
     rm


### PR DESCRIPTION
No real changes except removing the call to ssl.match_hostname (it was deprecated way back in 3.7 and removed completely in 3.12)