### PR TITLE
Reduce httpbin dependency

### DIFF
--- a/src/geventhttpclient/tests/test_no_module_ssl.py
+++ b/src/geventhttpclient/tests/test_no_module_ssl.py
@@ -33,4 +33,4 @@ def test_httpclient_raises_with_no_ssl():
         from geventhttpclient import HTTPClient
 
         with pytest.raises(Exception):
-            HTTPClient.from_url("https://httpbin.org/")
+            HTTPClient.from_url("https://somesslhost.org/")


### PR DESCRIPTION
- Make httpbin host configurable
- Make some client tests not network independent
- Regroup network dependent tests
- Largely fixes #198 flaky httpbin test
