### PR TITLE
Better headers

### DIFF
--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -83,7 +83,7 @@ class HTTPClient:
         headers_type=Headers,
     ):
         if headers is None:
-            headers = {}
+            headers = headers_type()
         self.host = host
         self.port = port
         connection_host = self.host

--- a/src/geventhttpclient/header.py
+++ b/src/geventhttpclient/header.py
@@ -5,112 +5,115 @@ _dict_getitem = dict.__getitem__
 _dict_delitem = dict.__delitem__
 _dict_contains = dict.__contains__
 _dict_setdefault = dict.setdefault
+_dict_items = dict.items
+_dict_values = dict.values
 
 
 class Headers(dict):
     """
     :param headers:
-        An iterable of field-value pairs. Must not contain multiple field names
-        when compared case-insensitively.
+        An iterable of field-value pairs.
 
     :param kwargs:
-        Additional field-value pairs to pass in to ``dict.update``.
+        Additional field-value pairs to pass in to ``Headers.extend``.
 
     A ``dict`` like container for storing HTTP Headers.
 
-    Field names are stored and compared case-insensitively in compliance with
-    RFC 7230. Iteration provides the first case-sensitive key seen for each
-    case-insensitive pair.
+    According to RFC 7230, header field names have to be treated case-insentitive.
+    This means `SET-COOKIE` as header field denotes the same field as `set-cookie`.
 
-    Using ``__setitem__`` syntax overwrites fields that compare equal
-    case-insensitively in order to maintain ``dict``'s api. For fields that
-    compare equal, instead create a new ``Headers`` and use ``.add``
-    in a loop.
+    In order to implement this behavior efficiently, all header names are lowered
+    and used as dictionary key for fast access of certain header lines. The original
+    case-sensitive header field is stored alongside the values under the hood.
 
-    If multiple fields that are equal case-insensitively are passed to the
-    constructor or ``.update``, the behavior is undefined and some will be
-    lost.
+    Iterating over Header.items() returns all field-value pairs with the original
+    cases. The order of the returned items matches the input order, except that
+    headers with a matching header field are grouped.
 
-    Note: b'asdf' and 'u'asdf' are separate things. This class tries not to
+    Use Header.__setitem__() and Header.update() for overwriting the content
+    of matching header fields and .add() and .extend() for appending header
+    lines instead of overwriting them.
+
+    Note: b"asdf" and "asdf" are separate things. This class tries not to
     enforce the one or the other.
 
     >>> headers = Headers()
     >>> headers.add('Set-Cookie', 'foo=bar')
     >>> headers.add('set-cookie', 'baz=quxx')
-    >>> headers['content-length'] = '7'
     >>> headers['SET-cookie']
-    'foo=bar, baz=quxx'
+    ['foo=bar', 'baz=quxx']
+    >>> headers['content-length'] = '7'
     >>> headers['Content-Length']
     '7'
+    >>> headers
+    Headers({'Set-Cookie': 'foo=bar, baz=quxx', 'content-length': '7'})
     """
 
     def __init__(self, headers=None, **kwargs):
         dict.__init__(self)
         if headers is not None:
-            if isinstance(headers, Headers):
+            if isinstance(headers, type(self)):
                 self._copy_from(headers)
             else:
                 self.extend(headers)
         if kwargs:
             self.extend(kwargs)
 
-    def __setitem__(self, key, val):
-        return _dict_setitem(self, key.lower(), (key, val))
+    def __setitem__(self, field, value):
+        return _dict_setitem(self, field.lower(), (field, value))
 
-    def __getitem__(self, key):
-        val = _dict_getitem(self, key.lower())
-        if len(val) == 2:
-            return val[1]
-        return val[1:]
+    def __getitem__(self, field):
+        vals = _dict_getitem(self, field.lower())
+        if isinstance(vals, tuple):
+            return vals[1]
+        return [val[1] for val in vals]
 
-    def __delitem__(self, key):
-        return _dict_delitem(self, key.lower())
+    def __delitem__(self, field):
+        return _dict_delitem(self, field.lower())
 
-    def __contains__(self, key):
-        return _dict_contains(self, key.lower())
+    def __contains__(self, field):
+        return _dict_contains(self, field.lower())
 
     def __eq__(self, other):
         if not isinstance(other, Mapping) and not hasattr(other, "keys"):
             return False
         if not isinstance(other, type(self)):
             other = type(self)(other)
-        return {k1: self[k1] for k1 in self} == {k2: other[k2] for k2 in other}
+        return {f1: self[f1] for f1 in self} == {f2: other[f2] for f2 in other}
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     values = MutableMapping.values
     get = MutableMapping.get
-    update = MutableMapping.update
     keys = MutableMapping.keys
 
     __marker = object()
 
-    def pop(self, key, default=__marker):
-        """D.pop(k[,d]) -> v, remove specified key and return the corresponding value.
-        If key is not found, d is returned if given, otherwise KeyError is raised.
+    def pop(self, field, default=__marker):
+        """D.pop(field[,default]) -> value, remove specified field and return the corresponding value.
+        If field is not found, d is returned if given, otherwise KeyError is raised.
         """
         # Using the MutableMapping function directly fails due to the private marker.
         # Using ordinary dict.pop would expose the internal structures.
         # So let's reinvent the wheel.
         try:
-            value = self[key]
+            value = self[field]
         except KeyError:
             if default is self.__marker:
                 raise
             return default
-        else:
-            del self[key]
-            return value
+        del self[field]
+        return value
 
-    def discard(self, key):
+    def discard(self, field):
         try:
-            del self[key]
+            del self[field]
         except KeyError:
             pass
 
-    def add(self, key, val):
-        """Adds a (name, value) pair, doesn't overwrite the value if it already
+    def add(self, field, value):
+        """Add a (field, value) pair without overwriting the value if it already
         exists.
 
         >>> headers = Headers(foo='bar')
@@ -118,19 +121,20 @@ class Headers(dict):
         >>> headers['foo']
         'bar, baz'
         """
-        key_lower = key.lower()
-        new_vals = key, val
+        field_lower = field.lower()
+        new_vals = field, value
         # Keep the common case aka no item present as fast as possible
-        vals = _dict_setdefault(self, key_lower, new_vals)
+        vals = _dict_setdefault(self, field_lower, new_vals)
         if new_vals is not vals:
             # new_vals was not inserted, as there was a previous one
-            if isinstance(vals, list):
-                # If already several items got inserted, we have a list
-                vals.append(val)
+            if isinstance(vals, tuple):
+                # Only one item so far, create a list and append new_vals
+                _dict_setitem(self, field_lower, [vals, new_vals])
+            elif isinstance(vals, list):
+                # Already several items got inserted, we have a list
+                vals.append(new_vals)
             else:
-                # vals should be a tuple then, i.e. only one item so far
-                # Need to convert the tuple to list for further extension
-                _dict_setitem(self, key_lower, [vals[0], vals[1], val])
+                raise TypeError("invalid vals stored")
 
     def extend(self, *args, **kwargs):
         """Generic import function for any type of header-like object.
@@ -141,92 +145,133 @@ class Headers(dict):
             raise TypeError(f"extend() takes at most 1 positional argument ({len(args)} given)")
         other = args[0] if len(args) >= 1 else ()
 
-        if isinstance(other, Headers):
-            for key, val in other.items():
-                self.add(key, val)
+        if isinstance(other, type(self)):
+            for field, value in other.items():
+                self.add(field, value)
         elif isinstance(other, Mapping):
-            for key in other:
-                self.add(key, other[key])
+            for field in other:
+                self.add(field, other[field])
         elif hasattr(other, "keys"):
-            for key in other.keys():
-                self.add(key, other[key])
+            for field in other.fields():
+                self.add(field, other[field])
         else:
-            for key, value in other:
-                self.add(key, value)
+            for field, value in other:
+                self.add(field, value)
 
-        for key, value in kwargs.items():
-            self.add(key, value)
+        for field, value in kwargs.items():
+            self.add(field, value)
 
-    def getlist(self, key):
+    def update(self, *args, **kwargs):
+        """Generic import function for any type of header-like object.
+        Adapted version of MutableMapping.update in order to overwrite items
+        while preserving case-sensitive header fields.
+        """
+        if len(args) > 1:
+            raise TypeError(f"extend() takes at most 1 positional argument ({len(args)} given)")
+        other = args[0] if len(args) >= 1 else ()
+
+        if isinstance(other, type(self)):
+            for field, value in other.items():
+                self[field] = value
+        elif isinstance(other, Mapping):
+            for field in other:
+                self[field] = other[field]
+        elif hasattr(other, "keys"):
+            for field in other.keys():
+                self[field] = other[field]
+        else:
+            for field, value in other:
+                self[field] = value
+
+        for field, value in kwargs.items():
+            self[field] = value
+
+    def getlist(self, field):
         """Returns a list of all the values for the named field. Returns an
-        empty list if the key doesn't exist."""
+        empty list if the field doesn't exist.
+        """
         try:
-            vals = _dict_getitem(self, key.lower())
+            vals = _dict_getitem(self, field.lower())
         except KeyError:
             return []
-        else:
-            if isinstance(vals, tuple):
-                return [vals[1]]
-            else:
-                return vals[1:]
+        if isinstance(vals, tuple):
+            return [vals[1]]
+        return [val[1] for val in vals]
 
-    # Backwards compatibility for httplib
-    getheaders = getlist
-    getallmatchingheaders = getlist
-    iget = getlist
-
-    # Python3 compatibility
-    def get_all(self, key, failobj=None):
-        vals = self.getlist(key)
-        if not vals:
+    def get_all(self, field, failobj=None):
+        values = self.getlist(field)
+        if not values:
             return failobj
-        return vals
-
-    def __repr__(self):
-        return f"{type(self).__name__}({dict(self.itermerged())})"
+        return values
 
     def _copy_from(self, other):
-        for key in other:
-            val = _dict_getitem(other, key)
-            if isinstance(val, list):
-                # Don't need to convert tuples
-                val = list(val)
-            _dict_setitem(self, key, val)
+        for field in other:
+            vals = _dict_getitem(other, field)
+            if isinstance(vals, list):
+                # No need to clone immutable tuples, only lists
+                vals = list(vals)
+            _dict_setitem(self, field, vals)
 
     def copy(self):
         clone = type(self)()
         clone._copy_from(self)
         return clone
 
-    def itermerged(self):
-        """Iterate over all headers, merging duplicate ones together."""
-        for key in self:
-            val = _dict_getitem(self, key)
-            # this should preserve either binary or string type
-            sep = ", " if isinstance(val[1], str) else b", "
-            yield val[0], sep.join(val[1:])
-
-    # Extensions to urllib3, compatibility to previous implementation
     def __len__(self):
-        return sum(len(self.getlist(key)) for key in self)
+        return sum(1 if isinstance(vals, tuple) else len(vals) for vals in _dict_values(self))
+
+    def __repr__(self):
+        return f"{type(self).__name__}({dict(self.itermerged())})"
+
+    def __str__(self):
+        """Return a similar string as the original HTTP text received for parsing. Lines with
+        matching header fields are grouped.
+        """
+        return "\n".join(f"{field}: {value}" for field, value in self.items())
+
+    def itermerged(self):
+        """Iterate over all headers, merging lines with duplicate header
+        fields together into one item. The case of the first header field
+        is preserved.
+        """
+        for field, vals in _dict_items(self):
+            if isinstance(vals, tuple):
+                yield vals
+            else:
+                # this should preserve either binary or string type
+                sep = ", " if isinstance(vals[0][0], str) else b", "
+                yield vals[0][0], sep.join(val[1] for val in vals)
 
     def compatible_dict(self):
+        """Create a dictionary. Header lines with duplicate field names are
+        merged into one line. This can be used for exchange with other
+        libraries.
+        """
         return dict(self.itermerged())
 
     def iterlower(self):
-        for key in self:
-            vals = _dict_getitem(self, key)
-            for val in vals[1:]:
-                yield key, val
-
-    iteritems = iterlower
+        """Iterate over all header lines, including duplicate ones.
+        The header fields are all lowered.
+        """
+        for field, vals in _dict_items(self):
+            if isinstance(vals, tuple):
+                yield field, vals[1]
+            else:
+                for val in vals:
+                    yield field, val[1]
 
     def items(self):
-        return list(self.iterlower())
-
-    def iteroriginal(self):
         """Iterate over all header lines, including duplicate ones."""
-        for key in self:
-            vals = _dict_getitem(self, key)
-            for val in vals[1:]:
-                yield vals[0], val
+        for field, vals in _dict_items(self):
+            if isinstance(vals, tuple):
+                yield vals
+            else:
+                yield from vals
+
+    # Backwards compatibility for httplib
+    getheaders = getlist
+    getallmatchingheaders = getlist
+    iget = getlist
+
+    # deprecated
+    iteroriginal = items

--- a/src/geventhttpclient/httplib.py
+++ b/src/geventhttpclient/httplib.py
@@ -4,7 +4,6 @@ to use as drop-in replacements for their counterparts in http.client.
 """
 
 import http.client as httplib
-import ssl
 
 import gevent.socket
 import gevent.ssl
@@ -103,7 +102,7 @@ class HTTPResponse(response.HTTPSocketResponse):
         return self.get(name.lower(), default)
 
     def getheaders(self):
-        return self._headers_index.items()
+        return list(self._headers_index.items())
 
     @property
     def will_close(self):

--- a/src/geventhttpclient/tests/test_client.py
+++ b/src/geventhttpclient/tests/test_client.py
@@ -79,7 +79,7 @@ def httpbin():
 
 @pytest.mark.parametrize("request_uri", ["/tp/", "tp/", f"http://{HTTPBIN_HOST}/tp/"])
 def test_build_request(httpbin, request_uri):
-    request_ref = f"GET /tp/ HTTP/1.1\r\nuser-agent: python/gevent-http-client-{__version__}\r\nhost: {HTTPBIN_HOST}\r\n\r\n"
+    request_ref = f"GET /tp/ HTTP/1.1\r\nUser-Agent: python/gevent-http-client-{__version__}\r\nHost: {HTTPBIN_HOST}\r\n\r\n"
     assert httpbin._build_request("GET", request_uri) == request_ref
 
 

--- a/src/geventhttpclient/tests/test_headers.py
+++ b/src/geventhttpclient/tests/test_headers.py
@@ -85,6 +85,15 @@ def test_create_from_list():
     assert h["cookie"][-1] == "E"
 
 
+def test_retrieve():
+    h = Headers([("ab", "A"), ("cd", "B"), ("cookie", "C"), ("cookie", "D"), ("cookie", "E")])
+    for key, ref in {"ab": "A", "cd": "B", "cookie": ["C", "D", "E"]}.items():
+        assert h[key] == ref
+        assert h.get(key) == ref
+        assert h.pop(key) == ref
+        assert key not in h
+
+
 def test_case_insensitivity():
     h = Headers({"Content-Type": "text/plain"})
     h.add("Content-Encoding", "utf8")
@@ -95,6 +104,22 @@ def test_case_insensitivity():
         assert h.get(val.lower()) == h.get(val.upper()) == h.get(val.capitalize())
         del h[val.upper()]
         assert val.lower() not in h
+
+
+def test_preserve_case():
+    h = Headers(Cookie="C", COOKIE="D", cookie="E", asdf="E")
+    assert len(h) == 4
+    assert h["cookie"] == ["C", "D", "E"]
+    assert list(h.items()) == [("Cookie", "C"), ("COOKIE", "D"), ("cookie", "E"), ("asdf", "E")]
+
+
+def test_update_preserve_case():
+    h = Headers()
+    h.update(COOKIE="A", Cookie="C")
+    assert list(h.items()) == [("Cookie", "C")]
+    h = Headers()
+    h.update(dict(Cookie="C", COOKIE="D", cookiE="E"))
+    assert list(h.items()) == [("cookiE", "E")]
 
 
 def test_read_multiple_header():
@@ -179,6 +204,11 @@ def test_header_replace():
     d["Content-Type"] = "text/plain"
     d["content-type"] = "text/html"
     assert d["content-type"] == "text/html"
+
+
+def test_formatting():
+    h = Headers(asdf="ddd", ASDF="fff", AsDf="asdfasdf")
+    assert str(h) == "asdf: ddd\nASDF: fff\nAsDf: asdfasdf"
 
 
 def test_compat_dict():

--- a/src/geventhttpclient/tests/test_parser.py
+++ b/src/geventhttpclient/tests/test_parser.py
@@ -81,14 +81,14 @@ def test_parse_small_blocks():
     assert parser.should_keep_alive()
     assert parser.status_code == 301
     assert sorted(parser.items()) == [
-        ("cache-control", "public, max-age=2592000"),
-        ("content-length", "218"),
-        ("content-type", "text/html; charset=UTF-8"),
-        ("date", "Thu, 13 Oct 2011 15:03:12 GMT"),
-        ("expires", "Sat, 12 Nov 2011 15:03:12 GMT"),
-        ("location", "http://www.google.fr/"),
-        ("server", "gws"),
-        ("x-xss-protection", "1; mode=block"),
+        ("Cache-Control", "public, max-age=2592000"),
+        ("Content-Length", "218"),
+        ("Content-Type", "text/html; charset=UTF-8"),
+        ("Date", "Thu, 13 Oct 2011 15:03:12 GMT"),
+        ("Expires", "Sat, 12 Nov 2011 15:03:12 GMT"),
+        ("Location", "http://www.google.fr/"),
+        ("Server", "gws"),
+        ("X-XSS-Protection", "1; mode=block"),
     ]
 
 

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -30,9 +30,7 @@ def wsgiserver(handler):
 
 def check_upload(body, headers=None):
     def wsgi_handler(env, start_response):
-        if headers:
-            # For Python 2.6 which does not have viewitems
-            assert env.items() >= headers.items()
+        assert env["REQUEST_METHOD"] == "POST"
         assert body == env["wsgi.input"].read()
         start_response("200 OK", [])
         return []

--- a/src/geventhttpclient/useragent.py
+++ b/src/geventhttpclient/useragent.py
@@ -103,7 +103,7 @@ class CompatRequest:
         return header_name in self.headers
 
     def header_items(self):
-        return self.headers.items()
+        return list(self.headers.items())
 
     def add_unredirected_header(self, key, val):
         self.headers.add(key, val)
@@ -509,7 +509,7 @@ class UserAgent:
 
     @classmethod
     def _conversation_str(cls, url, resp, payload=None):
-        header_str = "\n".join(f"{key}: {val}" for key, val in resp.headers.iteroriginal())
+        header_str = "\n".join(f"{key}: {val}" for key, val in resp.headers.items())
         ret = "REQUEST: " + url + "\n" + resp._sent_request
         if payload:
             if isinstance(payload, bytes):


### PR DESCRIPTION
Currently, the original case sensitive header fields are only preserved for the first lines with matching header fields. This is nothing too bad, as the RFC only demands a correct case-insensitive treatment, but it's not nice as well.

This PR now stores all case-sensitive header fields along with the header values. While at the same time it sticks with the principle of handling a single header field without any duplication, as default case with nearly the handling speed of an ordinary python dictionary.

Iterating over all header lines with their original cases is now the default behaviour of Header.items() and Headers.iteroriginal() is deprecated. So as a result, Headers can now be formatted nearly as the plain HTTP hext received over the wire.

```python
>>> h = Headers(asdf="ddd", ASDF="fff", AsDf="asdfasdf")
>>> print(h)
asdf: ddd
ASDF: fff
AsDf: asdfasdf
```
