### PR TITLE
URL refactoring

### DIFF
--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -146,14 +146,10 @@ class HTTPClient:
         self.default_headers.update(self.DEFAULT_HEADERS)
         self.default_headers.update(headers)
         self.block_size = block_size
-        self._base_url_string = str(self.get_base_url())
 
-    def get_base_url(self):
-        url = URL()
-        url.host = self.host
-        url.port = self.port
-        url.scheme = self.ssl and PROTO_HTTPS or PROTO_HTTP
-        return url
+        scheme = PROTO_HTTPS if self.ssl else PROTO_HTTP
+        port_str = f":{port}" if port else ""
+        self._base_url_string = f"{scheme}://{self.host}{port_str}/"
 
     def close(self):
         self._connection_pool.close()

--- a/src/geventhttpclient/tests/test_url.py
+++ b/src/geventhttpclient/tests/test_url.py
@@ -2,16 +2,16 @@ import pytest
 
 from geventhttpclient.url import URL
 
-url_full = "http://getgauss.com/subdir/file.py?param=value&other=true#frag"
+url_full = "http://gevent.org/subdir/file.py?param=value&other=true#frag"
 url_path_only = "/path/to/something?param=value&other=true"
 
 
 def test_simple_url():
     url = URL(url_full)
     assert url.path == "/subdir/file.py"
-    assert url.host == "getgauss.com"
+    assert url.host == "gevent.org"
     assert url.port == 80
-    assert url.query_string == "param=value&other=true"
+    assert url.query == "param=value&other=true"
     assert url.fragment == "frag"
 
 
@@ -20,46 +20,63 @@ def test_path_only():
     assert url.host == ""
     assert url.port is None
     assert url.path == "/path/to/something"
-    assert url.query_string == "param=value&other=true"
+    assert url.query == "param=value&other=true"
 
 
 def test_params():
     url = URL(url_full, params={"pp": "hello"})
     assert url.path == "/subdir/file.py"
-    assert url.host == "getgauss.com"
+    assert url.host == "gevent.org"
     assert url.port == 80
-    assert url.query_string == "param=value&other=true&pp=hello"
+    assert url.query == "param=value&other=true&pp=hello"
     assert url.fragment == "frag"
 
 
 def test_params_urlencoded():
     url = URL(url_full, params={"a/b": "c/d"})
     assert url.path == "/subdir/file.py"
-    assert url.host == "getgauss.com"
+    assert url.host == "gevent.org"
     assert url.port == 80
-    assert url.query_string == "param=value&other=true&a%2Fb=c%2Fd"
+    assert url.query == "param=value&other=true&a%2Fb=c%2Fd"
     assert url.fragment == "frag"
 
 
-def test_query_string_urlencoded():
-    url = URL("http://getgauss.com/?foo=bar with spaces")
-    assert url.query_string == "foo=bar%20with%20spaces"
-    assert url.host == "getgauss.com"
+def test_query_urlencoded():
+    url = URL("http://gevent.org/?foo=bar with spaces")
+    assert url.query == "foo=bar%20with%20spaces"
+    assert url.host == "gevent.org"
     assert url.port == 80
+
+
+def test_tuple_unpack():
+    url = URL("http://gevent.org/somepath?foo=bar#frag")
+    assert len(tuple(url)) == 6
+    scheme, netloc, path, params, query, fragment = url
+    assert scheme == "http"
+    assert netloc == "gevent.org"
+    assert path == "/somepath"
+    assert query == "foo=bar"
+    assert fragment == "frag"
+
+
+def test_tuple_unpack_no_none():
+    url = URL("http://gevent.org/")
+    assert len(tuple(url)) == 6
+    assert not any(val is None for val in tuple(url))
 
 
 def test_empty():
     url = URL()
     assert url.host == ""
-    assert url.port == 80
-    assert url.query_string == ""
+    assert not url.port
+    assert url.query == ""
     assert url.fragment == ""
     assert url.netloc == ""
-    assert str(url) == "http:///"
+    assert str(url) == ""
 
 
 def test_empty_path():
-    assert URL("http://getgauss.com").path == ""
+    assert URL("http://gevent.org").path == ""
 
 
 def test_consistent_reparsing():
@@ -76,7 +93,7 @@ def test_redirection_abs_path():
     assert updated.host == url.host
     assert updated.port == url.port
     assert updated.path == "/test.html"
-    assert updated.query_string == ""
+    assert updated.query == ""
     assert updated.fragment == ""
 
 
@@ -88,7 +105,7 @@ def test_redirection_rel_path(redirection):
     assert updated.port == url.port
     assert updated.path.startswith("/subdir/")
     assert updated.path.endswith(redirection.split("?", 1)[0])
-    assert updated.query_string == "key=val"
+    assert updated.query == "key=val"
     assert updated.fragment == ""
 
 
@@ -102,8 +119,8 @@ def test_redirection_full_path():
     assert str(url_full2) == url_full2_plain
 
 
-def test_query_string():
-    assert URL("/some/url", params={"a": "b", "c": 2}).query_string == "a=b&c=2"
+def test_query():
+    assert URL("/some/url", params={"a": "b", "c": 2}).query == "a=b&c=2"
 
 
 def test_equality():
@@ -111,17 +128,23 @@ def test_equality():
     assert URL("http://example.com/") == URL("http://example.com/")
 
 
+def test_default_port():
+    assert URL("https://gevent.org").port == 443
+    assert URL("http://httpbingo.org").port == 80
+    assert URL("example.com").port is None
+
+
 def test_pw():
-    url = URL("http://asdf:dd@heise.de/index.php?aaaa=bbbbb")
-    assert url.host == "heise.de"
+    url = URL("http://asdf:dd@example.com/index.php?aaaa=bbbbb")
+    assert url.host == "example.com"
     assert url.port == 80
     assert url.user == "asdf"
     assert url.password == "dd"
 
 
 def test_pw_with_port():
-    url = URL("http://asdf:dd@heise.de:90/index.php?aaaa=bbbbb")
-    assert url.host == "heise.de"
+    url = URL("http://asdf:dd@example.com:90/index.php?aaaa=bbbbb")
+    assert url.host == "example.com"
     assert url.port == 90
     assert url.user == "asdf"
     assert url.password == "dd"
@@ -131,11 +154,11 @@ def test_ipv6():
     url = URL("http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/")
     assert url.host == "2001:db8:85a3:8d3:1319:8a2e:370:7348"
     assert url.port == 80
-    assert url.user is None
+    assert url.user == ""
 
 
 def test_ipv6_with_port():
     url = URL("https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:8080/")
     assert url.host == "2001:db8:85a3:8d3:1319:8a2e:370:7348"
     assert url.port == 8080
-    assert url.user is None
+    assert url.user == ""

--- a/src/geventhttpclient/url.py
+++ b/src/geventhttpclient/url.py
@@ -1,8 +1,137 @@
 from collections.abc import Mapping
 from urllib import parse as urlparse
-from urllib.parse import urlencode
 
 DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+class URL:
+    """Immutable URL class
+
+    You build it from an url string.
+    >>> url = URL('http://python.org/urls?param=asdfa')
+    >>> url
+    URL(http://python.org/urls?param=asdfa)
+
+    You cast it to a tuple, it returns the same tuple as `urlparse.urlsplit`.
+    >>> tuple(url)
+    ('http', 'python.org', '/urls', 'param=asdfa', '')
+
+    You can cast it as a string.
+    >>> str(url)
+    'http://python.org/urls?param=asdfa'
+    """
+
+    __slots__ = ("_parsed",)
+
+    def __init__(self, url="", params=None):
+        if isinstance(url, str):
+            parsed = urlparse.urlparse(url)
+        else:
+            parsed = url
+        scheme, netloc, path, parsed_params, query, fragment = parsed
+
+        if params is not None:
+            new_params = _encode_params(params)
+            query = query + "&" + new_params if query else new_params
+        if query:
+            # get a little closer to the behaviour of requests.utils.requote_uri
+            query = query.replace(" ", "%20")
+        self._parsed = urlparse.ParseResult(scheme, netloc, path, parsed_params, query, fragment)
+
+    def __str__(self):
+        return self._parsed.geturl()
+
+    def __repr__(self):
+        return f"URL({self})"
+
+    def __iter__(self):
+        return (val if val is not None else "" for val in self._parsed)
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            other = type(self)(other)
+        return self._parsed == other._parsed
+
+    def __getattr__(self, attr):
+        value = getattr(self._parsed, attr)
+        # backwards compatibility: never return None for URL parts
+        return value if value is not None else ""
+
+    @property
+    def host(self):
+        return self.hostname
+
+    @property
+    def user(self):
+        return self.username
+
+    @property
+    def port(self):
+        port = self._parsed._hostinfo[1]
+        if port is not None:
+            if port.isdigit() and port.isascii():
+                port = int(port)
+            else:
+                raise ValueError(f"Port could not be cast to integer value as {port!r}")
+            if not (0 <= port <= 65535):
+                raise ValueError("Port out of range 0-65535")
+        else:
+            port = DEFAULT_PORTS.get(self._parsed.scheme)
+        return port
+
+    @property
+    def query_string(self):
+        return self.query
+
+    @property
+    def request_uri(self):
+        if not self.query:
+            return self.path
+        return self.path + "?" + self.query
+
+    def redirect(self, other):
+        """Redirect to the other URL, relative to the current one."""
+        if isinstance(other, str):
+            other = URL(other)
+
+        if other.netloc:
+            return other
+
+        # relative redirect
+        scheme, netloc, path, params, query, fragment = other
+        scheme = self.scheme
+        netloc = self.netloc
+        if not path.startswith("/"):
+            if path.endswith("/"):
+                path = self.path + path
+            else:
+                path = self.path.rstrip("/") + "/" + path
+        parsed = urlparse.ParseResult(scheme, netloc, path, params, query, fragment)
+        return type(self)(parsed)
+
+
+def _encode_params(data):
+    """Encode parameters in a piece of data.
+    Will successfully encode parameters when passed as a dict or a list of 2-tuples.
+    """
+
+    if isinstance(data, (str, bytes)):
+        return data
+    if hasattr(data, "__iter__"):
+        result = []
+        for k, vs in to_key_val_list(data):
+            if isinstance(vs, (str, bytes)) or not hasattr(vs, "__iter__"):
+                vs = [vs]
+            for v in vs:
+                if v is not None:
+                    result.append(
+                        (
+                            k.encode("utf-8") if isinstance(k, str) else k,
+                            v.encode("utf-8") if isinstance(v, str) else v,
+                        )
+                    )
+        return urlparse.urlencode(result, doseq=True)
+    return data
 
 
 def to_key_val_list(value):
@@ -29,218 +158,3 @@ def to_key_val_list(value):
         value = value.items()
 
     return list(value)
-
-
-class URL:
-    """A mutable URL class
-
-    You build it from a url string.
-    >>> url = URL('http://getgauss.com/urls?param=asdfa')
-    >>> url
-    URL(http://getgauss.com/urls?param=asdfa)
-
-    You cast it to a tuple, it returns the same tuple as `urlparse.urlsplit`.
-    >>> tuple(url)
-    ('http', 'getgauss.com', '/urls', 'param=asdfa', '')
-
-    You can cast it as a string.
-    >>> str(url)
-    'http://getgauss.com/urls?param=asdfa'
-
-    You can change attributes.
-    >>> url.host = 'infrae.com'
-    >>> url
-    URL(http://infrae.com/urls?auth_token=asdfaisdfuasdf&param=asdfa)
-    """
-
-    __slots__ = (
-        "scheme",
-        "host",
-        "port",
-        "path",
-        "query",
-        "fragment",
-        "user",
-        "password",
-        "params",
-    )
-    quoting_safe = ""
-
-    def __init__(self, url=None, params=None):
-        if url is not None:
-            scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
-        else:
-            scheme, netloc, path, query, fragment = "http", "", "/", "", ""
-
-        self.scheme = scheme
-        self.fragment = fragment
-
-        user, password, host, port = None, None, "", None
-        if netloc:
-            if "@" in netloc:
-                user_pw, netloc = netloc.rsplit("@", 1)
-                if ":" in user_pw:
-                    user, password = user_pw.rsplit(":", 1)
-                else:
-                    user = user_pw
-
-            if netloc.startswith("["):
-                host, port_pt = netloc.rsplit("]", 1)
-                host = host.strip("[]")
-                if port_pt:
-                    port = int(port_pt.strip(":"))
-            else:
-                if ":" in netloc:
-                    host, port = netloc.rsplit(":", 1)
-                    port = int(port)
-                else:
-                    host = netloc
-
-        if not port:
-            port = DEFAULT_PORTS.get(self.scheme)
-
-        self.host = host
-        self.port = port
-        self.user = user
-        self.password = password
-
-        self.path = path or ""
-
-        self.query = query.replace(
-            " ", "%20"
-        )  # get a little closer to the behaviour of requests.utils.requote_uri
-        self.params = params
-
-    @property
-    def netloc(self):
-        return self.full_netloc(auth=False)
-
-    def full_netloc(self, auth=True):
-        buf = ""
-        if self.user and auth:
-            buf += self.user
-            if self.password:
-                buf += ":" + self.password
-            buf += "@"
-
-        if ":" in self.host:
-            buf += "[" + self.host + "]"
-        else:
-            buf += self.host
-        if self.port is None:
-            return buf
-        elif DEFAULT_PORTS.get(self.scheme) == self.port:
-            return buf
-        buf += ":" + str(self.port)
-        return buf
-
-    def __copy__(self):
-        clone = type(self)()
-        for key in self.__slots__:
-            val = getattr(self, key)
-            if isinstance(val, dict):
-                val = val.copy()
-            setattr(clone, key, val)
-        return clone
-
-    def __repr__(self):
-        return f"URL({self})"
-
-    def __iter__(self):
-        return iter(
-            (
-                self.scheme,
-                self.full_netloc(),
-                self.path,
-                self.query_string,
-                self.fragment,
-            )
-        )
-
-    def __str__(self):
-        return urlparse.urlunsplit(tuple(self))
-
-    def __eq__(self, other):
-        return str(self) == str(other)
-
-    @staticmethod
-    def _encode_params(data):
-        """Encode parameters in a piece of data.
-        Will successfully encode parameters when passed as a dict or a list of
-        2-tuples.
-        """
-
-        if isinstance(data, (str, bytes)):
-            return data
-        elif hasattr(data, "read"):
-            return data
-        elif hasattr(data, "__iter__"):
-            result = []
-            for k, vs in to_key_val_list(data):
-                if isinstance(vs, (str, bytes)) or not hasattr(vs, "__iter__"):
-                    vs = [vs]
-                for v in vs:
-                    if v is not None:
-                        result.append(
-                            (
-                                k.encode("utf-8") if isinstance(k, str) else k,
-                                v.encode("utf-8") if isinstance(v, str) else v,
-                            )
-                        )
-            return urlencode(result, doseq=True)
-        else:
-            return data
-
-    @property
-    def query_string(self):
-        query = []
-        if self.query:
-            query.append(self.query)
-        if self.params:
-            query.append(self._encode_params(self.params))
-        return "&".join(query)
-
-    @property
-    def request_uri(self):
-        query = self.query_string
-        if not query:
-            return self.path
-        return self.path + "?" + query
-
-    def append_to_path(self, value):
-        if value.startswith("/"):
-            if self.path.endswith("/"):
-                self.path += value[1:]
-                return self.path
-        elif not self.path.endswith("/"):
-            self.path += "/" + value
-            return self.path
-
-        self.path += value
-        return self.path
-
-    def redirect(self, other):
-        """Redirect to the other URL, relative to the current one"""
-        if not isinstance(other, type(self)):
-            other = type(self)(other)
-        if not other.host:
-            other.scheme = self.scheme
-            other.host = self.host
-            other.port = self.port
-        if not other.path.startswith("/"):
-            if self.path.endswith("/"):
-                other.path = self.path + other.path
-            else:
-                other.path = self.path.rsplit("/", 1)[0] + "/" + other.path
-        return other
-
-    def stripped_auth(self):
-        """Remove fragment and authentication for proxy handling"""
-        clone = type(self)()
-        # Copy all fields except fragment, username and password
-        for key in self.__slots__[:5]:
-            val = getattr(self, key)
-            if isinstance(val, dict):
-                val = val.copy()
-            setattr(clone, key, val)
-        return clone

--- a/src/geventhttpclient/useragent.py
+++ b/src/geventhttpclient/useragent.py
@@ -11,8 +11,8 @@ import gevent
 from urllib3 import encode_multipart_formdata
 from urllib3.fields import RequestField
 
-from .client import HTTPClient, HTTPClientPool
-from .url import URL, to_key_val_list
+from geventhttpclient.client import HTTPClient, HTTPClientPool
+from geventhttpclient.url import URL, to_key_val_list
 
 
 class ConnectionError(Exception):


### PR DESCRIPTION
The current URL implementation did quite some parsing, which is nowadays already done in a more robust and clean way in the standard library. This PR preserves the previous URL interface, while leaving all the actual work to `urllib.parse.urlparse` and `urllib.parse.ParseResult`.

It would be debatable, if we shouldn't drop the url module entirely and just use `urllib.parse` and all tools within directly without any wrapping. Mb something to keep in mind for a potential future major version bump.