### PR TITLE
Fixes #40 max_retries and max_redirects

### DIFF
--- a/src/geventhttpclient/connectionpool.py
+++ b/src/geventhttpclient/connectionpool.py
@@ -1,5 +1,4 @@
 import os
-from contextlib import contextmanager
 
 import gevent.queue
 import gevent.socket
@@ -264,30 +263,3 @@ else:
             else:
                 server_hostname = self.ssl_options.get("server_hostname", self._request_host)
                 return self.ssl_context.wrap_socket(sock, server_hostname=server_hostname)
-
-
-class ClientPool:
-    """
-    Pool implementation for HTTP clients, that weren't designed with concurrency in mind.
-    Usage example:
-
-    pool = ClientPool(MyHttpClient)
-    with pool.get() as client:
-        response = client.request("127.0.0.1")
-    """
-
-    def __init__(self, factory, concurrency=5):
-        self.factory = factory
-        self.queue = gevent.queue.Queue(concurrency)
-        for i in range(concurrency):
-            self.queue.put(factory())
-
-    @contextmanager
-    def get(self):
-        client = self.queue.get()
-        yield client
-        self.queue.put(client)
-
-    def close(self):
-        for client in self.queue:
-            client.close()

--- a/src/geventhttpclient/useragent.py
+++ b/src/geventhttpclient/useragent.py
@@ -434,11 +434,11 @@ class UserAgent:
             params=params,
             files=files,
         )
-        for retry in range(self.max_retries):
+        for retry in range(self.max_retries + 1):
             if retry > 0 and self.retry_delay:
                 # Don't wait the first time and skip if no delay specified
                 gevent.sleep(self.retry_delay)
-            for _ in range(self.max_redirects):
+            for _ in range(self.max_redirects + 1):
                 if self.cookiejar is not None:
                     self.cookiejar.add_cookie_header(req)
 
@@ -547,7 +547,7 @@ class UserAgent:
         else:
             offset = 0
 
-        for _ in range(self.max_retries):
+        for _ in range(self.max_retries + 1):
             if offset:
                 headers["Range"] = f"bytes={offset}-"
                 resp = self.urlopen(url, headers=headers, **kwargs)


### PR DESCRIPTION
- `UserAgent` `max_retries=` and `max_redirects=` kw args now don't count the initial attempt. I.e. they actually behave like "max_retries" and not "max_tries".
- `ClientPool` for httplib2 moved to httplib2. It should never have been in `connectionpool.py`.