### PR TITLE
requests compatibility layer

### DIFF
--- a/src/geventhttpclient/__init__.py
+++ b/src/geventhttpclient/__init__.py
@@ -2,6 +2,8 @@
 
 __version__ = "2.2.1"  # dont forget to update version in pyproject.toml as well
 
+from geventhttpclient.api import delete, get, head, options, patch, post, put, request
 from geventhttpclient.client import HTTPClient
+from geventhttpclient.requests import Session
 from geventhttpclient.url import URL
 from geventhttpclient.useragent import UserAgent

--- a/src/geventhttpclient/api.py
+++ b/src/geventhttpclient/api.py
@@ -1,0 +1,157 @@
+"""
+This module mimics and blatantly borrows with all due respect
+from the excellent and rightfully popular Requests API.
+
+Copyright of the original requests project:
+
+:copyright: (c) 2012 by Kenneth Reitz.
+:license: Apache2, see LICENSE for more details.
+"""
+
+import geventhttpclient.requests
+
+
+def request(method, url, **kw):
+    """Constructs and sends a HTTP request. WARNING: Only a subset of the following parameters is currently supported
+
+    :param method: method for the new request object: ``GET``, ``OPTIONS``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    :param url: URL for the new HTTP Request object.
+    :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the HTTP Request.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the HTTP Request.
+    :param json: (optional) A JSON serializable Python object to send in the body of the HTTP Request.
+    :param headers: (optional) Dictionary of HTTP Headers to send with the HTTP Request.
+    :param cookies: (optional) Dict or CookieJar object to send with the HTTP Request.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
+        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
+        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content-type'`` is a string
+        defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
+        to add for the file.
+    :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
+    :param timeout: (optional) How many seconds to wait for the server to send data
+        before giving up, as a float, or a :ref:`(connect timeout, read
+        timeout) <timeouts>` tuple.
+    :type timeout: float or tuple
+    :param allow_redirects: (optional) Boolean. Enable/disable GET/OPTIONS/POST/PUT/PATCH/DELETE/HEAD redirection. Defaults to ``True``.
+    :type allow_redirects: bool
+    :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
+    :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a string, in which case it must be a path
+            to a CA bundle to use. Defaults to ``True``.
+    :param stream: (optional) if ``False``, the response content will be immediately downloaded.
+    :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
+    :return: HTTP Response object
+    :rtype: HTTP Response
+
+    Usage::
+
+      >>> import geventhttpclient
+      >>> req = geventhttpclient.request('GET', 'https://httpbingo.org/get')
+      >>> req
+      <Response [200]>
+    """
+
+    # By using the 'with' statement we are sure the session is closed, thus we
+    # avoid leaving sockets open which can trigger a ResourceWarning in some
+    # cases, and look like a memory leak in others.
+    with geventhttpclient.requests.Session() as session:
+        return session.request(method=method, url=url, **kw)
+
+
+def get(url, params=None, **kw):
+    r"""Sends a GET request.
+
+    :param url: URL for the new HTTP Request object.
+    :param params: (optional) Dictionary, list of tuples or bytes to send
+        in the query string for the HTTP Request.
+    :param \*\*kw: Optional arguments that ``request`` takes.
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    return request("get", url, params=params, **kw)
+
+
+def options(url, **kw):
+    r"""Sends an OPTIONS request.
+
+    :param url: URL for the new HTTP Request object.
+    :param \*\*kw: Optional arguments that ``request`` takes.
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    return request("options", url, **kw)
+
+
+def head(url, **kw):
+    r"""Sends a HEAD request.
+
+    :param url: URL for the new HTTP Request object.
+    :param \*\*kw: Optional arguments that ``request`` takes. If
+        `allow_redirects` is not provided, it will be set to `False` (as
+        opposed to the default :meth:`request` behavior).
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    kw.setdefault("allow_redirects", False)
+    return request("head", url, **kw)
+
+
+def post(url, data=None, json=None, **kw):
+    r"""Sends a POST request.
+
+    :param url: URL for the new HTTP Request object.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the HTTP Request.
+    :param json: (optional) A JSON serializable Python object to send in the body of the HTTP Request.
+    :param \*\*kw: Optional arguments that ``request`` takes.
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    return request("post", url, data=data, json=json, **kw)
+
+
+def put(url, data=None, **kw):
+    r"""Sends a PUT request.
+
+    :param url: URL for the new HTTP Request object.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the HTTP Request.
+    :param json: (optional) A JSON serializable Python object to send in the body of the HTTP Request.
+    :param \*\*kw: Optional arguments that ``request`` takes.
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    return request("put", url, data=data, **kw)
+
+
+def patch(url, data=None, **kw):
+    r"""Sends a PATCH request.
+
+    :param url: URL for the new HTTP Request object.
+    :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+        object to send in the body of the HTTP Request.
+    :param json: (optional) A JSON serializable Python object to send in the body of the HTTP Request.
+    :param \*\*kw: Optional arguments that ``request`` takes.
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    return request("patch", url, data=data, **kw)
+
+
+def delete(url, **kw):
+    r"""Sends a DELETE request.
+
+    :param url: URL for the new HTTP Request object.
+    :param \*\*kw: Optional arguments that ``request`` takes.
+    :return: HTTP Response object
+    :rtype: requests.Response
+    """
+
+    return request("delete", url, **kw)

--- a/src/geventhttpclient/client.py
+++ b/src/geventhttpclient/client.py
@@ -297,9 +297,9 @@ class HTTPClientPool:
 
     # TODO: Add some housekeeping and cleanup logic
 
-    def __init__(self, **kwargs):
-        self.clients = dict()
-        self.client_args = kwargs
+    def __init__(self, **kw):
+        self.clients = {}
+        self.client_args = kw
 
     def get_client(self, url):
         if not isinstance(url, URL):

--- a/src/geventhttpclient/header.py
+++ b/src/geventhttpclient/header.py
@@ -268,10 +268,28 @@ class Headers(dict):
             else:
                 yield from vals
 
-    # Backwards compatibility for httplib
+    # Compatibility with http.client
     getheaders = getlist
     getallmatchingheaders = getlist
-    iget = getlist
 
-    # deprecated
-    iteroriginal = items
+    def iteroriginal(self):
+        import warnings
+
+        warnings.warn(
+            "This is deprecated and will be removed in version v2.3.0. "
+            "Use Headers.items() instead.",
+            DeprecationWarning,
+            2,
+        )
+        return self.items()
+
+    def iget(self, field):
+        import warnings
+
+        warnings.warn(
+            "This is deprecated and will be removed in version v2.3.0. "
+            "Use Headers.getlist() instead.",
+            DeprecationWarning,
+            2,
+        )
+        return self.getlist(field)

--- a/src/geventhttpclient/requests.py
+++ b/src/geventhttpclient/requests.py
@@ -1,0 +1,252 @@
+import json as jsonlib
+from http.cookiejar import CookieJar
+
+from geventhttpclient import useragent
+
+
+class RequestsRequest(useragent.CompatRequest):
+    @property
+    def body(self):
+        return self.payload
+
+
+class RequestsResponse(useragent.CompatResponse):
+    @property
+    def request(self):
+        return self._request
+
+    @property
+    def ok(self):
+        return 100 <= self.status_code < 400
+
+    @property
+    def reason(self):
+        return self._response.status_message
+
+    @property
+    def url(self):
+        return self._request.url
+
+    @property
+    def is_redirect(self):
+        """True if this Response is a well-formed HTTP redirect that could have
+        been processed automatically (by :meth:`Session.resolve_redirects`).
+        """
+        return "location" in self.headers and self.status_code in range(300, 310)
+
+    @property
+    def raw(self):
+        return self.stream
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            raise useragent.BadStatusCode(self.url, code=self.status_code)
+
+
+class Session(useragent.UserAgent):
+    """This class mimics and blatantly borrows with all due respect
+    from the excellent and rightfully popular Requests API.
+
+    Copyright of the original requests project:
+
+    :copyright: (c) 2012 by Kenneth Reitz.
+    :license: Apache2, see LICENSE for more details.
+    """
+
+    request_type = RequestsRequest
+    response_type = RequestsResponse
+
+    def get(self, url, **kw):
+        r"""Sends a GET request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        kw.setdefault("allow_redirects", True)
+        return self.request("GET", url, **kw)
+
+    def options(self, url, **kw):
+        r"""Sends a OPTIONS request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        kw.setdefault("allow_redirects", True)
+        return self.request("OPTIONS", url, **kw)
+
+    def head(self, url, **kw):
+        r"""Sends a HEAD request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        kw.setdefault("allow_redirects", False)
+        return self.request("HEAD", url, **kw)
+
+    def post(self, url, data=None, json=None, **kw):
+        r"""Sends a POST request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the HTTP Request.
+        :param json: (optional) json to send in the body of the HTTP Request.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        return self.request("POST", url, data=data, json=json, **kw)
+
+    def put(self, url, data=None, **kw):
+        r"""Sends a PUT request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the HTTP Request.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        return self.request("PUT", url, data=data, **kw)
+
+    def patch(self, url, data=None, **kw):
+        r"""Sends a PATCH request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the HTTP Request.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        return self.request("PATCH", url, data=data, **kw)
+
+    def delete(self, url, **kw):
+        r"""Sends a DELETE request. Returns a HTTP Response object.
+
+        :param url: URL for the new a HTTP Request object.
+        :param \*\*kw: Optional arguments that ``request`` takes.
+        :rtype: CompatResponse
+        """
+
+        return self.request("DELETE", url, **kw)
+
+    def request(
+        self,
+        method,
+        url,
+        params=None,
+        data=None,
+        headers=None,
+        cookies=None,
+        files=None,
+        auth=None,
+        timeout=None,
+        allow_redirects=True,
+        proxies=None,
+        hooks=None,
+        stream=None,
+        verify=None,
+        cert=None,
+        json=None,
+    ):
+        """Constructs and sends a HTTP request, returns a HTTP Response object.
+
+        NOTE: Only a subset of these parameters is currently (fully) supported.
+        And it's also not
+
+        :param method: method for the new request object.
+        :param url: URL for the new request object.
+        :param params: (optional) Dictionary or bytes to be sent in the query
+            string for the request.
+        :param data: (optional) Dictionary, list of tuples, bytes, or file-like
+            object to send in the body of the request.
+        :param json: (optional) json to send in the body of the
+            HTTP Request.
+        :param headers: (optional) Dictionary of HTTP Headers to send with the
+            HTTP Request.
+        :param cookies: (optional) Dict or CookieJar object to send with the
+            HTTP Request.
+        :param files: (optional) Dictionary of ``'filename': file-like-objects``
+            for multipart encoding upload.
+        :param auth: (optional) Auth tuple or callable to enable
+            Basic/Digest/Custom HTTP Auth.
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+        :type timeout: float or tuple
+        :param allow_redirects: (optional) Set to True by default.
+        :type allow_redirects: bool
+        :param proxies: (optional) Dictionary mapping protocol or protocol and
+            hostname to the URL of the proxy.
+        :param stream: (optional) whether to immediately download the response
+            content. Defaults to ``False``.
+        :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a string, in which case it must be a path
+            to a CA bundle to use. Defaults to ``True``. When set to
+            ``False``, requests will accept any TLS certificate presented by
+            the server, and will ignore hostname mismatches and/or expired
+            certificates, which will make your application vulnerable to
+            man-in-the-middle (MitM) attacks. Setting verify to ``False``
+            may be useful during local development or testing.
+        :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair.
+        :rtype: CompatResponse
+        """
+        for param_name, param in dict(timeout=timeout, cert=cert, verify=verify).items():
+            if param is not None:
+                raise ValueError(
+                    f"{param} can not be set on a per-request basis. Please configure the UserAgent instead."
+                )
+        for param_name, param in dict(
+            cookies=cookies, auth=auth, proxies=proxies, hooks=hooks
+        ).items():
+            if param is not None:
+                raise NotImplementedError(
+                    f"{param} is currently unsupported as a keyword argument."
+                )
+        for param_name, param in dict(hooks=hooks).items():
+            if param is not None:
+                raise NotImplementedError(f"{param} is not supported")
+
+        if json:
+            if data:
+                raise ValueError("Can send either data or json, not both at once")
+            data = jsonlib.dumps(json)
+            if headers is None:
+                headers = {}
+            headers["Content-Type"] = "application/json"
+
+        response = self.urlopen(
+            url,
+            method=method.upper(),
+            headers=headers,
+            files=files,
+            payload=data or None,
+            params=params,
+            max_redirects=None if allow_redirects else 0,
+        )
+        if stream is False:
+            # preload the data
+            _ = response.content
+        return response
+
+    def __init__(self, *args, **kw):
+        """
+        requests.Session has no arguments at all. Unfortunately, we're relying way more
+        on configuring the Session / UserAgent, while requests focuses more on
+        configuring the single requests.
+        """
+        kw.setdefault("max_redirects", 30)
+        super().__init__(*args, **kw)
+        if not self.cookiejar:
+            self.cookiejar = CookieJar()
+
+    def _verify_status(self, status_code, url=None):
+        # Don't raise, whatever the status is
+        pass

--- a/src/geventhttpclient/response.py
+++ b/src/geventhttpclient/response.py
@@ -50,6 +50,7 @@ class HTTPResponse(HTTPResponseParser):
     headers = property(items)
 
     def info(self):
+        # compatibility with http.client
         return self._headers_index
 
     def __contains__(self, key):

--- a/src/geventhttpclient/tests/test_requests.py
+++ b/src/geventhttpclient/tests/test_requests.py
@@ -1,0 +1,14 @@
+import pytest
+
+from geventhttpclient.header import Headers
+from geventhttpclient.requests import Session
+from geventhttpclient.tests.conftest import HTTPBIN_HOST
+
+
+@pytest.mark.network
+def test_no_form_encode_header():
+    url = f"https://{HTTPBIN_HOST}/headers"
+    hdrs = Headers(Session().get(url).json()["headers"])
+    print(hdrs)
+    assert "content-type" not in hdrs
+    assert "content-length" not in hdrs

--- a/src/geventhttpclient/tests/test_useragent.py
+++ b/src/geventhttpclient/tests/test_useragent.py
@@ -2,6 +2,7 @@ from http.cookiejar import CookieJar
 
 import pytest
 
+from geventhttpclient.header import Headers
 from geventhttpclient.tests.conftest import HTTPBIN_HOST, LISTENER_URL, check_upload, wsgiserver
 from geventhttpclient.useragent import BadStatusCode, UserAgent
 
@@ -248,6 +249,15 @@ def test_brotli_response():
         resp = UserAgent().urlopen(LISTENER_URL, params={"path": "/"})
         assert resp.status_code == 200
         assert resp.content == b"https://github.com/gwik/geventhttpclient"
+
+
+@pytest.mark.network
+def test_no_form_encoded_header():
+    url = f"https://{HTTPBIN_HOST}/headers"
+    hdrs = Headers(UserAgent().urlopen(url).json()["headers"])
+    print(hdrs)
+    assert "content-type" not in hdrs
+    assert "content-length" not in hdrs
 
 
 @pytest.mark.network


### PR DESCRIPTION
Up for discussion. This currently allows things like:

```python
import geventhttpclient as requests
requests.get("https://github.com").text
requests.post("http://httpbingo.org/post", data="asdfasd").json()

from geventhttpclient.requests import Session
s = Session()
s.get("http://httpbingo.org/headers").json()
s.get("https://github.com").content
```

One main issue is, that requests allows a lot of configuration on a per-request basis, while geventhttpclient currently expects most configuration on the HTTPClient / UserAgent.

Also, what about the license? I don't have much clue about these issues. requests is Apache licensed, geventhttpclient has "mainly" MIT. Apache allows re-licensing, as far as I understood. Do we have to add something, or is the mentioning so far good enough?

Also, tests are nearly absent so far.

Of course, it's missing a lot of features of requests. Mainly proxy support, chunked encoding, some authentication etc etc. I still think it might be useful for a couple of standard cases.