### PR TITLE
test: Increase the read of the TLS handshake in sni_checker_server()

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -164,7 +164,7 @@ def sni_checker_server():
     def run(sock):
         while True:
             conn, addr = sock.accept()
-            client_hello = conn.recv(1024)
+            client_hello = conn.recv(4096)
             return extract_sni_from_client_hello(client_hello)
 
     def extract_sni_from_client_hello(hello_packet):


### PR DESCRIPTION
Original report: https://bugs.debian.org/1102957

If only the first 1KiB of the TLS packet is read then there should be no surprise if things don't work out if something changes. Newer openssl stuffs more bytes into the handshake so the test failed.

Read 4KiB now and hope of the best.

